### PR TITLE
check argument list length up front

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -25,11 +25,10 @@ contributors: Kevin Gibbons
   <emu-alg>
     1. Let _state_ be ~minus-zero~.
     1. Let _sum_ be 0.
-    1. Let _count_ be 0.
+    1. If the number of elements in _args_ ≥ 2<sup>53</sup>, then
+      1. NOTE: This step is not expected to be reached in practice and is included only so that implementations may rely on inputs being "reasonably sized" without violating this specification.
+      1. Throw a *RangeError* exception.
     1. For each element _arg_ of _args_, do
-      1. Set _count_ to _count_ + 1.
-      1. If _count_ ≥ 2<sup>53</sup>, throw a *RangeError* exception.
-      1. NOTE: The above case is not expected to be reached in practice and is included only so that implementations may rely on inputs being "reasonably sized" without violating this specification.
       1. Let _n_ be ? ToNumber(_arg_).
       1. If _state_ is not ~not-a-number~, then
         1. If _n_ is *NaN*, set _state_ to ~not-a-number~.


### PR DESCRIPTION
I'm guessing this was left over from a version that took an iterator?

Also, do we really need to do this in `Math.sum`? It seems like if we're going to do this anywhere, we should make it apply everywhere.