### PR TITLE
don't ever say "here" for link text

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -57,6 +57,6 @@ contributors: Kevin Gibbons
     1. If _state_ is ~minus-infinity~, return *-∞*<sub>𝔽</sub>.
     1. If _state_ is ~minus-zero~, return *-0*<sub>𝔽</sub>.
     1. Return 𝔽(_sum_).
-    1. NOTE: The value of _sum_ can be computed without arbitrary-precision arithmetic by a variety of algorithms. One such is the "Grow-Expansion" algorithm given in <i>Adaptive Precision Floating-Point Arithmetic and Fast Robust Geometric Predicates</i> by Jonathan Richard Shewchuk. A more recent algorithm is given in "<a href="https://arxiv.org/abs/1505.05571">Fast exact summation using small and large superaccumulators</a>", code for which is available <a href="https://gitlab.com/radfordneal/xsum">here</a>.
+    1. NOTE: The value of _sum_ can be computed without arbitrary-precision arithmetic by a variety of algorithms. One such is the "Grow-Expansion" algorithm given in <i>Adaptive Precision Floating-Point Arithmetic and Fast Robust Geometric Predicates</i> by Jonathan Richard Shewchuk. A more recent algorithm is given in "<a href="https://arxiv.org/abs/1505.05571">Fast exact summation using small and large superaccumulators</a>", code for which is available at <a href="https://gitlab.com/radfordneal/xsum">https://gitlab.com/radfordneal/xsum</a>.
   </emu-alg>
 </emu-clause>


### PR DESCRIPTION
Alternatively, we could say something like "on GitLab".